### PR TITLE
Bugfix: Bump earthkit-data version

### DIFF
--- a/conda/anemoi.yaml
+++ b/conda/anemoi.yaml
@@ -50,7 +50,7 @@ dependencies:
   - tqdm
   - boto3
   - requests
-  - earthkit-data[mars]<0.4.0
+  - earthkit-data[mars]<0.14.0
   - earthkit-geo
   - eccodes
   - entrypoints


### PR DESCRIPTION
Previously had restriction `earthkit-data[mars]<0.4.0` but this should be **14** not **4**